### PR TITLE
math: Added new math functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@
 /sqlite3x
 /.fslckout
 /sqlite3x.c
+/gh-md-toc
+/test.db

--- a/Makefile.in
+++ b/Makefile.in
@@ -68,7 +68,9 @@ TCC += -DSQLITE_THREADSAFE=@SQLITE_THREADSAFE@
 
 # Any target libraries which libsqlite must be linked against
 #
-TLIBS = @LIBS@ $(LIBS)
+# sqlite3x: "-lm" is required for some compilers to make sure the math library
+# is linked.
+TLIBS = @LIBS@ $(LIBS) -lm
 
 # Flags controlling use of the in memory btree implementation
 #
@@ -236,6 +238,7 @@ SRC = \
   $(TOP)/src/loadext.c \
   $(TOP)/src/main.c \
   $(TOP)/src/malloc.c \
+  $(TOP)/src/math.c \
   $(TOP)/src/mem0.c \
   $(TOP)/src/mem1.c \
   $(TOP)/src/mem2.c \
@@ -482,6 +485,7 @@ TESTSRC2 = \
   $(TOP)/src/insert.c \
   $(TOP)/src/wal.c \
   $(TOP)/src/main.c \
+  $(TOP)/src/math.c \
   $(TOP)/src/mem5.c \
   $(TOP)/src/os.c \
   $(TOP)/src/os_unix.c \
@@ -882,6 +886,9 @@ main.lo:	$(TOP)/src/main.c $(HDR)
 
 malloc.lo:	$(TOP)/src/malloc.c $(HDR)
 	$(LTCOMPILE) $(TEMP_STORE) -c $(TOP)/src/malloc.c
+
+math.lo:	$(TOP)/src/math.c $(HDR)
+	$(LTCOMPILE) $(TEMP_STORE) -c $(TOP)/src/math.c
 
 mem0.lo:	$(TOP)/src/mem0.c $(HDR)
 	$(LTCOMPILE) $(TEMP_STORE) -c $(TOP)/src/mem0.c
@@ -1450,7 +1457,7 @@ clean:
 	rm -f showjournal$(TEXE) showstat4$(TEXE) showwal$(TEXE) speedtest1$(TEXE)
 	rm -f wordcount$(TEXE) changeset$(TEXE)
 	rm -f sqlite3.dll sqlite3.lib sqlite3.exp sqlite3.def
-	rm -f sqlite3.c
+	rm -f sqlite3.c sqlite3x.c
 	rm -f sqlite3rc.h
 	rm -f shell.c sqlite3ext.h
 	rm -f sqlite3_analyzer$(TEXE) sqlite3_analyzer.c

--- a/Makefile.msc
+++ b/Makefile.msc
@@ -1305,6 +1305,7 @@ SRC00 = \
   $(TOP)\src\loadext.c \
   $(TOP)\src\main.c \
   $(TOP)\src\malloc.c \
+  $(TOP)\src\math.c \
   $(TOP)\src\mem0.c \
   $(TOP)\src\mem1.c \
   $(TOP)\src\mem2.c \
@@ -1979,6 +1980,9 @@ main.lo:	$(TOP)\src\main.c $(HDR)
 
 malloc.lo:	$(TOP)\src\malloc.c $(HDR)
 	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\malloc.c
+
+math.lo:	$(TOP)\src\math.c $(HDR)
+	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\math.c
 
 mem0.lo:	$(TOP)\src\mem0.c $(HDR)
 	$(LTCOMPILE) $(CORE_COMPILE_OPTS) -c $(TOP)\src\mem0.c

--- a/README.md
+++ b/README.md
@@ -1,4 +1,36 @@
-# sqlite3x
+# sqlite3x [![Build Status](https://travis-ci.org/elliotchance/sqlite3x.svg?branch=master)](https://travis-ci.org/elliotchance/sqlite3x)
+
+   * [Overview](#overview)
+   * [Features](#features)
+      * [Added Functions](#added-functions)
+         * [acos(X)](#acosx)
+         * [asin(X)](#asinx)
+         * [atan(X)](#atanx)
+         * [atan2(Y,X)](#atan2yx)
+         * [ceil(X)](#ceilx)
+         * [cos(X)](#cosx)
+         * [cosh(X)](#coshx)
+         * [e()](#e)
+         * [exp(X)](#expx)
+         * [floor(X)](#floorx)
+         * [log(X)](#logx)
+         * [log10(X)](#log10x)
+         * [pi()](#pi)
+         * [pow(X,Y)](#powxy)
+         * [sin(X)](#sinx)
+         * [sinh(X)](#sinhx)
+         * [sqrt(X)](#sqrtx)
+         * [tan(X)](#tanx)
+         * [tanh(X)](#tanhx)
+   * [Building From Source](#building-from-source)
+      * [Binary Client](#binary-client)
+      * [Amalgamation Source](#amalgamation-source)
+   * [Testing](#testing)
+   * [Updating SQLite3 Core](#updating-sqlite3-core)
+
+
+Overview
+========
 
 sqlite3x is a fork of the sqlite3 codebase that provides 100% compatibility with
 sqlite3. Data read or modified in either sqlite3 ot sqlite3x is always
@@ -10,6 +42,167 @@ modifications that sit on top of the engine, such as new functions.
 The only compatibility issues will be that if you use sqlite3x functions, they
 will obviously not be available for use in queries on a vanilla sqlite3 command
 line or linked library.
+
+
+Features
+========
+
+Added Functions
+---------------
+
+On top of the [sqlite3 built-in functions](
+https://www.sqlite.org/lang_corefunc.html), sqlite3x adds:
+
+### acos(X)
+
+acos(X) returns the arc-cosine of *X*. If *X* is `NULL`, then the result will be
+`NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `1.5707963267949`.
+
+### asin(X)
+
+asin(X) returns the arc-sine of *X*. If *X* is `NULL`, then the result will be
+`NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `0.0`.
+
+### atan(X)
+
+atan(X) returns the arc-tangent of *X*. If *X* is `NULL`, then the result will
+be `NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `0.0`.
+
+### atan2(Y,X)
+
+atan2(Y,X) returns arc-tangent with *Y* and *X*. `NULL` is returned if either of
+the inputs are `NULL`.
+
+You should be careful that inputs are valid and sensible. atan2(Y,X) does not
+provide any protection for values that are invalid (not valid numbers).
+
+### ceil(X)
+
+ceil(X) rounds *X* upward, returning the smallest integral value that is not
+less than *X*. If *X* is `NULL`, then the result will be `NULL`, otherwise the
+result will always be a floating-point value.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `0.0`.
+
+### cos(X)
+
+cos(X) returns the cosine of *X* (*X* is expressed in radians). If *X* is
+`NULL`, then the result will be `NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `1.0`.
+
+### cosh(X)
+
+cosh(X) returns the hyperbolic cosine of *X*. If *X* is `NULL`, then the result
+will be `NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `0.0`.
+
+### e()
+
+e() returns the value of e, which is approximately 2.71828.
+
+### exp(X)
+
+exp(X) returns *e* to the power of *X*. If *X* is `NULL`, then the result will
+be `NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `1.0`.
+
+exp(X) does not provide any protection for result values that are too small or
+large (overflow) will have unexpected behavior depending on your system.
+
+### floor(X)
+
+floor(X) rounds *X* downward, returning the largest integral value that is not
+greater than *X*. If *X* is `NULL`, then the result will be `NULL`, otherwise
+the result will always be a floating-point value.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `0.0`.
+
+### log(X)
+
+log(X) returns natural logarithm (base *e*) of *X*. If *X* is `NULL`, then the
+result will be `NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `-Inf`.
+
+### log10(X)
+
+log10(X) returns common logarithm (base 10) of *X*. If *X* is `NULL`, then the
+result will be `NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `-Inf`.
+
+### pi()
+
+pi() returns the value of pi, which is approximately 3.14159.
+
+### pow(X,Y)
+
+pow(X,Y) returns *X* to the power of *Y*. The result is always a floating-point
+value. `NULL` is returned if either of the inputs are `NULL`.
+
+You should be careful that inputs are valid and sensible. pow(X,Y) does not
+provide any protection for values that are invalid (not valid numbers). Result
+values that are too small or large (overflow) will have unexpected behavior
+depending on your system.
+
+### sin(X)
+
+sin(X) returns the sine of *X* (*X* is expressed in radians). If *X* is `NULL`,
+then the result will be `NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `0.0`.
+
+### sinh(X)
+
+sinh(X) returns the hyperbolic sine of *X*. If *X* is `NULL`, then the result
+will be `NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `0.0`.
+
+### sqrt(X)
+
+sqrt(X) returns the square root of *X*. If *X* is `NULL`, then the result will
+be `NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `0.0`.
+
+### tan(X)
+
+tan(X) returns the tangent of *X* (*X* is expressed in radians). If *X* is
+`NULL`, then the result will be `NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `0.0`.
+
+### tanh(X)
+
+tanh(X) returns the hyperbolic tangent of *X*. If *X* is `NULL`, then the result
+will be `NULL`.
+
+If *X* not numeric then it will be treated internally as `0.0`. This will
+produce a result of `0.0`.
 
 
 Building From Source
@@ -70,11 +263,7 @@ It can take some time to run the full suite. If you want to run a specific test
 you can use:
 
 ```bash
-# Only needs to be run once to build the binary.
-make testfixture
-
-# Execute testfixture with a list of test files.
-./testfixture test/main.test
+make testfixture && ./testfixture test/main.test
 ```
 
 Updating SQLite3 Core

--- a/main.mk
+++ b/main.mk
@@ -113,6 +113,7 @@ SRC = \
   $(TOP)/src/loadext.c \
   $(TOP)/src/main.c \
   $(TOP)/src/malloc.c \
+  $(TOP)/src/math.c \
   $(TOP)/src/mem0.c \
   $(TOP)/src/mem1.c \
   $(TOP)/src/mem2.c \
@@ -401,6 +402,7 @@ TESTSRC2 = \
   $(TOP)/src/insert.c \
   $(TOP)/src/wal.c \
   $(TOP)/src/main.c \
+  $(TOP)/src/math.c \
   $(TOP)/src/mem5.c \
   $(TOP)/src/os.c \
   $(TOP)/src/os_unix.c \

--- a/src/func.c
+++ b/src/func.c
@@ -2011,6 +2011,7 @@ void sqlite3RegisterBuiltinFunctions(void){
     FUNCTION(coalesce,           0, 0, 0, 0                ),
     INLINE_FUNC(coalesce,       -1, INLINEFUNC_coalesce, SQLITE_FUNC_COALESCE),
   };
+  sqlite3xMathFunctions();
 #ifndef SQLITE_OMIT_ALTERTABLE
   sqlite3AlterFunctions();
 #endif

--- a/src/math.c
+++ b/src/math.c
@@ -1,0 +1,394 @@
+// This file is not part of the core sqlite3 codebase. It is part of the
+// github.com/elliotchance/sqlite3x project.
+//
+// This file provides more math functions than are otherwise not included with
+// sqlite3.
+
+#include "sqliteInt.h"
+#include <math.h>
+
+// cos(X) returns the cosine of *X* (*X* is expressed in radians). If *X* is
+// `NULL`, then the result will be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `1.0`.
+static void cosFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, cos(x));
+}
+
+// sin(X) returns the sine of *X* (*X* is expressed in radians). If *X* is
+// `NULL`, then the result will be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `0.0`.
+static void sinFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, sin(x));
+}
+
+// tan(X) returns the tangent of *X* (*X* is expressed in radians). If *X* is
+// `NULL`, then the result will be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `0.0`.
+static void tanFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, tan(x));
+}
+
+// pow(X,Y) returns *X* to the power of *Y*. The result is always a
+// floating-point value. `NULL` is returned if either of the inputs are `NULL`.
+//
+// You should be careful that inputs are valid and sensible. pow(X,Y) does not
+// provide any protection for values that are invalid (not valid numbers).
+// Result values that are too small or large (overflow) will have unexpected
+// behavior depending on your system.
+static void powFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 2);
+  UNUSED_PARAMETER(argc);
+
+  // If either argument is NULL, the result also must be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL ||
+      sqlite3_value_type(argv[1]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  // All operations are handled as floating-point. If either of the inputs
+  // cannot be resolved to a float then the result is unexpected.
+  //
+  // It might be nice to have pow() return an integer if both inputs are
+  // integers. I did try this initially, but ran into some problems detecting
+  // integer overflows when the result is just ove the max signed int64 (see
+  // LARGEST_INT64). Without being able to correctly detect the overflow it
+  // would produce bad results, so it's paramount if its ever implemented again
+  // that there is a test case for "pow(2, 63)".
+  double x = sqlite3_value_double(argv[0]);
+  double y = sqlite3_value_double(argv[1]);
+  sqlite3_result_double(context, pow(x, y));
+}
+
+// pi() returns the value of pi, which is approximately 3.14159.
+static void piFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 0);
+  UNUSED_PARAMETER(argc);
+
+  sqlite3_result_double(context, M_PI);
+}
+
+// e() returns the value of e, which is approximately 2.71828.
+static void eFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 0);
+  UNUSED_PARAMETER(argc);
+
+  sqlite3_result_double(context, M_E);
+}
+
+// acos(X) returns the arc-cosine of *X*. If *X* is `NULL`, then the result will
+// be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `1.5707963267949`.
+static void acosFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, acos(x));
+}
+
+// asin(X) returns the arc-sine of *X*. If *X* is `NULL`, then the result will
+// be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `0.0`.
+static void asinFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, asin(x));
+}
+
+// atan(X) returns the arc-tangent of *X*. If *X* is `NULL`, then the result
+// will be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `0.0`.
+static void atanFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, atan(x));
+}
+
+// atan2(Y,X) returns arc-tangent with *Y* and *X*. `NULL` is returned if either
+// of the inputs are `NULL`.
+//
+// You should be careful that inputs are valid and sensible. atan2(Y,X) does not
+// provide any protection for values that are invalid (not valid numbers).
+static void atan2Func(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 2);
+  UNUSED_PARAMETER(argc);
+
+  // If either argument is NULL, the result also must be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL ||
+      sqlite3_value_type(argv[1]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double y = sqlite3_value_double(argv[0]);
+  double x = sqlite3_value_double(argv[1]);
+  sqlite3_result_double(context, atan2(y, x));
+}
+
+// cosh(X) returns the hyperbolic cosine of *X*. If *X* is `NULL`, then the
+// result will be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `0.0`.
+static void coshFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, cosh(x));
+}
+
+// sinh(X) returns the hyperbolic sine of *X*. If *X* is `NULL`, then the result
+// will be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `0.0`.
+static void sinhFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, sinh(x));
+}
+
+// tanh(X) returns the hyperbolic tangent of *X*. If *X* is `NULL`, then the
+// result will be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `0.0`.
+static void tanhFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, tanh(x));
+}
+
+// exp(X) returns *e* to the power of *X*. If *X* is `NULL`, then the result
+// will be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `1.0`.
+//
+// exp(X) does not provide any protection for result values that are too small
+// or large (overflow) will have unexpected behavior depending on your system.
+static void expFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, exp(x));
+}
+
+// log(X) returns natural logarithm (base *e*) of *X*. If *X* is `NULL`, then
+// the result will be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `-Inf`.
+static void logFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, log(x));
+}
+
+// log10(X) returns common logarithm (base 10) of *X*. If *X* is `NULL`, then
+// the result will be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `-Inf`.
+static void log10Func(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, log10(x));
+}
+
+// sqrt(X) returns the square root of *X*. If *X* is `NULL`, then the result
+// will be `NULL`.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `0.0`.
+static void sqrtFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, sqrt(x));
+}
+
+// ceil(X) rounds *X* upward, returning the smallest integral value that is not
+// less than *X*. If *X* is `NULL`, then the result will be `NULL`, otherwise
+// the result will always be a floating-point value.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `0.0`.
+static void ceilFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, ceil(x));
+}
+
+// floor(X) rounds *X* downward, returning the largest integral value that is
+// not greater than *X*. If *X* is `NULL`, then the result will be `NULL`,
+// otherwise the result will always be a floating-point value.
+//
+// If *X* not numeric then it will be treated internally as `0.0`. This will
+// produce a result of `0.0`.
+static void floorFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  // If the argument is NULL, the result must also be NULL.
+  if (sqlite3_value_type(argv[0]) == SQLITE_NULL) {
+    sqlite3_result_null(context);
+    return;
+  }
+
+  double x = sqlite3_value_double(argv[0]);
+  sqlite3_result_double(context, floor(x));
+}
+
+// Register the math functions in this file. This function should remain at the
+// bottom of the file because it references all of the functions above.
+void sqlite3xMathFunctions(void) {
+  static FuncDef funcs[] = {
+    FUNCTION(acos, 1, 0, 0, acosFunc),
+    FUNCTION(asin, 1, 0, 0, asinFunc),
+    FUNCTION(atan, 1, 0, 0, atanFunc),
+    FUNCTION(atan2, 2, 0, 0, atan2Func),
+    FUNCTION(ceil, 1, 0, 0, ceilFunc),
+    FUNCTION(cos, 1, 0, 0, cosFunc),
+    FUNCTION(cosh, 1, 0, 0, coshFunc),
+    FUNCTION(e, 0, 0, 0, eFunc),
+    FUNCTION(exp, 1, 0, 0, expFunc),
+    FUNCTION(floor, 1, 0, 0, floorFunc),
+    FUNCTION(log, 1, 0, 0, logFunc),
+    FUNCTION(log10, 1, 0, 0, log10Func),
+    FUNCTION(pi, 0, 0, 0, piFunc),
+    FUNCTION(pow, 2, 0, 0, powFunc),
+    FUNCTION(sin, 1, 0, 0, sinFunc),
+    FUNCTION(sinh, 1, 0, 0, sinhFunc),
+    FUNCTION(sqrt, 1, 0, 0, sqrtFunc),
+    FUNCTION(tan, 1, 0, 0, tanFunc),
+    FUNCTION(tanh, 1, 0, 0, tanhFunc),
+  };
+  sqlite3InsertBuiltinFuncs(funcs, ArraySize(funcs));
+}

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -4314,6 +4314,7 @@ FuncDef *sqlite3FindFunction(sqlite3*,const char*,int,u8,u8);
 void sqlite3RegisterBuiltinFunctions(void);
 void sqlite3RegisterDateTimeFunctions(void);
 void sqlite3RegisterPerConnectionBuiltinFunctions(sqlite3*);
+void sqlite3xMathFunctions(void);
 int sqlite3SafetyCheckOk(sqlite3*);
 int sqlite3SafetyCheckSickOrOk(sqlite3*);
 void sqlite3ChangeCookie(Parse*, int);

--- a/test/math.test
+++ b/test/math.test
@@ -1,0 +1,725 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+# Some of the results have been rounded to less precision because different
+# systems can produce very slightly different results. For example sin(2.5) has
+# been shown to produce the error:
+#
+# ! sin-float expected: [0.598472144103956]
+# ! sin-float got:      [0.598472144103957]
+
+# cos()
+
+do_execsql_test cos-float {
+  SELECT round(cos(2.5), 6);
+} {-0.801144}
+
+do_execsql_test cos-int {
+  SELECT round(cos(2), 6);
+} {-0.416147}
+
+do_execsql_test cos-string {
+  SELECT round(cos('2.75'), 6);
+} {-0.924302}
+
+do_execsql_test cos-zero {
+  SELECT cos(0);
+} {1.0}
+
+do_execsql_test cos-badarg-1 {
+  SELECT cos('foo');
+} {1.0}
+
+do_execsql_test cos-null {
+  SELECT cos(NULL);
+} {{}}
+
+do_test cos-args-0 {
+  catchsql {
+    SELECT cos();
+  }
+} {1 {wrong number of arguments to function cos()}}
+
+do_test cos-args-2 {
+  catchsql {
+    SELECT cos(1, 2);
+  }
+} {1 {wrong number of arguments to function cos()}}
+
+# sin()
+
+do_execsql_test sin-float {
+  SELECT round(sin(2.5), 6);
+} {0.598472}
+
+do_execsql_test sin-int {
+  SELECT round(sin(2), 6);
+} {0.909297}
+
+do_execsql_test sin-string {
+  SELECT round(sin('2.75'), 6);
+} {0.381661}
+
+do_execsql_test sin-zero {
+  SELECT sin(0);
+} {0.0}
+
+do_execsql_test sin-badarg-1 {
+  SELECT sin('foo');
+} {0.0}
+
+do_execsql_test sin-null {
+  SELECT sin(NULL);
+} {{}}
+
+do_test sin-args-0 {
+  catchsql {
+    SELECT sin();
+  }
+} {1 {wrong number of arguments to function sin()}}
+
+do_test sin-args-2 {
+  catchsql {
+    SELECT sin(1, 2);
+  }
+} {1 {wrong number of arguments to function sin()}}
+
+# tan()
+
+do_execsql_test tan-float {
+  SELECT round(tan(2.5), 6);
+} {-0.747022}
+
+do_execsql_test tan-int {
+  SELECT round(tan(2), 6);
+} {-2.18504}
+
+do_execsql_test tan-string {
+  SELECT round(tan('2.75'), 6);
+} {-0.412918}
+
+do_execsql_test tan-zero {
+  SELECT tan(0);
+} {0.0}
+
+do_execsql_test tan-badarg-1 {
+  SELECT tan('foo');
+} {0.0}
+
+do_execsql_test tan-null {
+  SELECT tan(NULL);
+} {{}}
+
+do_test tan-args-0 {
+  catchsql {
+    SELECT tan();
+  }
+} {1 {wrong number of arguments to function tan()}}
+
+do_test tan-args-2 {
+  catchsql {
+    SELECT tan(1, 2);
+  }
+} {1 {wrong number of arguments to function tan()}}
+
+# pow()
+
+do_execsql_test pow-float-float {
+  SELECT round(pow(2.5, 3.7), 6);
+} {29.674133}
+
+do_execsql_test pow-int-int {
+  SELECT pow(2, 3);
+} {8.0}
+
+do_execsql_test pow-float-int {
+  SELECT pow(2.5, 3);
+} {15.625}
+
+do_execsql_test pow-int-float {
+  SELECT round(pow(2, 3.7), 6);
+} {12.996038}
+
+do_execsql_test pow-badarg-1 {
+  SELECT pow('foo', 2.5);
+} {0.0}
+
+do_execsql_test pow-badarg-2 {
+  SELECT pow(2.5, 'foo');
+} {1.0}
+
+do_execsql_test pow-string-string {
+  SELECT pow('2.5', '-2');
+} {0.16}
+
+do_execsql_test pow-null-both {
+  SELECT pow(NULL, NULL);
+} {{}}
+
+do_execsql_test pow-null-x {
+  SELECT pow(NULL, 3);
+} {{}}
+
+do_execsql_test pow-null-y {
+  SELECT pow(2, NULL);
+} {{}}
+
+do_test pow-args-0 {
+  catchsql {
+    SELECT pow();
+  }
+} {1 {wrong number of arguments to function pow()}}
+
+do_test pow-args-1 {
+  catchsql {
+    SELECT pow(1);
+  }
+} {1 {wrong number of arguments to function pow()}}
+
+do_test pow-args-3 {
+  catchsql {
+    SELECT pow(1, 2, 3);
+  }
+} {1 {wrong number of arguments to function pow()}}
+
+# pi()
+
+do_execsql_test pi {
+  SELECT round(pi(), 6);
+} {3.141593}
+
+do_test pi-args-1 {
+  catchsql {
+    SELECT pi(1);
+  }
+} {1 {wrong number of arguments to function pi()}}
+
+# e()
+
+do_execsql_test e {
+  SELECT round(e(), 6);
+} {2.718282}
+
+do_test e-args-1 {
+  catchsql {
+    SELECT e(1);
+  }
+} {1 {wrong number of arguments to function e()}}
+
+# acos()
+
+do_execsql_test acos-float {
+  SELECT round(acos(0.5), 6);
+} {1.047198}
+
+do_execsql_test acos-int {
+  SELECT round(acos(0.6), 6);
+} {0.927295}
+
+do_execsql_test acos-string {
+  SELECT round(acos('0.75'), 6);
+} {0.722734}
+
+do_execsql_test acos-zero {
+  SELECT round(acos(0), 6);
+} {1.570796}
+
+do_execsql_test acos-badarg-1 {
+  SELECT round(acos('foo'), 6);
+} {1.570796}
+
+do_execsql_test acos-null {
+  SELECT acos(NULL);
+} {{}}
+
+do_test acos-args-0 {
+  catchsql {
+    SELECT acos();
+  }
+} {1 {wrong number of arguments to function acos()}}
+
+do_test acos-args-2 {
+  catchsql {
+    SELECT acos(1, 2);
+  }
+} {1 {wrong number of arguments to function acos()}}
+
+# asin()
+
+do_execsql_test asin-float {
+  SELECT round(asin(0.5), 6);
+} {0.523599}
+
+do_execsql_test asin-int {
+  SELECT round(asin(0.6), 6);
+} {0.643501}
+
+do_execsql_test asin-string {
+  SELECT round(asin('0.75'), 6);
+} {0.848062}
+
+do_execsql_test asin-zero {
+  SELECT asin(0);
+} {0.0}
+
+do_execsql_test asin-badarg-1 {
+  SELECT asin('foo');
+} {0.0}
+
+do_execsql_test asin-null {
+  SELECT asin(NULL);
+} {{}}
+
+do_test asin-args-0 {
+  catchsql {
+    SELECT asin();
+  }
+} {1 {wrong number of arguments to function asin()}}
+
+do_test asin-args-2 {
+  catchsql {
+    SELECT asin(1, 2);
+  }
+} {1 {wrong number of arguments to function asin()}}
+
+# atan()
+
+do_execsql_test atan-float {
+  SELECT round(atan(0.5), 6);
+} {0.463648}
+
+do_execsql_test atan-int {
+  SELECT round(atan(0.2), 6);
+} {0.197396}
+
+do_execsql_test atan-string {
+  SELECT round(atan('0.75'), 6);
+} {0.643501}
+
+do_execsql_test atan-zero {
+  SELECT atan(0);
+} {0.0}
+
+do_execsql_test atan-badarg-1 {
+  SELECT atan('foo');
+} {0.0}
+
+do_execsql_test atan-null {
+  SELECT atan(NULL);
+} {{}}
+
+do_test atan-args-0 {
+  catchsql {
+    SELECT atan();
+  }
+} {1 {wrong number of arguments to function atan()}}
+
+do_test atan-args-2 {
+  catchsql {
+    SELECT atan(1, 2);
+  }
+} {1 {wrong number of arguments to function atan()}}
+
+# atan2()
+
+do_execsql_test atan2-float-float {
+  SELECT round(atan2(2.5, 3.7), 6);
+} {0.594214}
+
+do_execsql_test atan2-int-int {
+  SELECT round(atan2(2, 3), 6);
+} {0.588003}
+
+do_execsql_test atan2-float-int {
+  SELECT round(atan2(2.5, 3), 6);
+} {0.694738}
+
+do_execsql_test atan2-int-float {
+  SELECT round(atan2(2, 3.7), 6);
+} {0.495552}
+
+do_execsql_test atan2-badarg-1 {
+  SELECT atan2('foo', 2.5);
+} {0.0}
+
+do_execsql_test atan2-badarg-2 {
+  SELECT round(atan2(2.5, 'foo'), 6);
+} {1.570796}
+
+do_execsql_test atan2-string-string {
+  SELECT round(atan2('2.5', '-2'), 6);
+} {2.245537}
+
+do_execsql_test atan2-null-both {
+  SELECT atan2(NULL, NULL);
+} {{}}
+
+do_execsql_test atan2-null-x {
+  SELECT atan2(NULL, 3);
+} {{}}
+
+do_execsql_test atan2-null-y {
+  SELECT atan2(2, NULL);
+} {{}}
+
+do_test atan2-args-0 {
+  catchsql {
+    SELECT atan2();
+  }
+} {1 {wrong number of arguments to function atan2()}}
+
+do_test atan2-args-1 {
+  catchsql {
+    SELECT atan2(1);
+  }
+} {1 {wrong number of arguments to function atan2()}}
+
+do_test atan2-args-3 {
+  catchsql {
+    SELECT atan2(1, 2, 3);
+  }
+} {1 {wrong number of arguments to function atan2()}}
+
+# cosh()
+
+do_execsql_test cosh-float {
+  SELECT round(cosh(2.5), 6);
+} {6.132289}
+
+do_execsql_test cosh-int {
+  SELECT round(cosh(2), 6);
+} {3.762196}
+
+do_execsql_test cosh-string {
+  SELECT round(cosh('2.75'), 6);
+} {7.85328}
+
+do_execsql_test cosh-zero {
+  SELECT cosh(0);
+} {1.0}
+
+do_execsql_test cosh-badarg-1 {
+  SELECT cosh('foo');
+} {1.0}
+
+do_execsql_test cosh-null {
+  SELECT cosh(NULL);
+} {{}}
+
+do_test cosh-args-0 {
+  catchsql {
+    SELECT cosh();
+  }
+} {1 {wrong number of arguments to function cosh()}}
+
+do_test cosh-args-2 {
+  catchsql {
+    SELECT cosh(1, 2);
+  }
+} {1 {wrong number of arguments to function cosh()}}
+
+# sinh()
+
+do_execsql_test sinh-float {
+  SELECT round(sinh(2.5), 6);
+} {6.050204}
+
+do_execsql_test sinh-int {
+  SELECT round(sinh(2), 6);
+} {3.62686}
+
+do_execsql_test sinh-string {
+  SELECT round(sinh('2.75'), 6);
+} {7.789352}
+
+do_execsql_test sinh-zero {
+  SELECT sinh(0);
+} {0.0}
+
+do_execsql_test sinh-badarg-1 {
+  SELECT sinh('foo');
+} {0.0}
+
+do_execsql_test sinh-null {
+  SELECT sinh(NULL);
+} {{}}
+
+do_test sinh-args-0 {
+  catchsql {
+    SELECT sinh();
+  }
+} {1 {wrong number of arguments to function sinh()}}
+
+do_test sinh-args-2 {
+  catchsql {
+    SELECT sinh(1, 2);
+  }
+} {1 {wrong number of arguments to function sinh()}}
+
+# tanh()
+
+do_execsql_test tanh-float {
+  SELECT round(tanh(2.5), 6);
+} {0.986614}
+
+do_execsql_test tanh-int {
+  SELECT round(tanh(2), 6);
+} {0.964028}
+
+do_execsql_test tanh-string {
+  SELECT round(tanh('2.75'), 6);
+} {0.99186}
+
+do_execsql_test tanh-zero {
+  SELECT tanh(0);
+} {0.0}
+
+do_execsql_test tanh-badarg-1 {
+  SELECT tanh('foo');
+} {0.0}
+
+do_execsql_test tanh-null {
+  SELECT tanh(NULL);
+} {{}}
+
+do_test tanh-args-0 {
+  catchsql {
+    SELECT tanh();
+  }
+} {1 {wrong number of arguments to function tanh()}}
+
+do_test tanh-args-2 {
+  catchsql {
+    SELECT tanh(1, 2);
+  }
+} {1 {wrong number of arguments to function tanh()}}
+
+# exp()
+
+do_execsql_test exp-float {
+  SELECT round(exp(2.5), 6);
+} {12.182494}
+
+do_execsql_test exp-int {
+  SELECT round(exp(2), 6);
+} {7.389056}
+
+do_execsql_test exp-string {
+  SELECT round(exp('2.75'), 6);
+} {15.642632}
+
+do_execsql_test exp-zero {
+  SELECT exp(0);
+} {1.0}
+
+do_execsql_test exp-badarg-1 {
+  SELECT exp('foo');
+} {1.0}
+
+do_execsql_test exp-null {
+  SELECT exp(NULL);
+} {{}}
+
+do_test exp-args-0 {
+  catchsql {
+    SELECT exp();
+  }
+} {1 {wrong number of arguments to function exp()}}
+
+do_test exp-args-2 {
+  catchsql {
+    SELECT exp(1, 2);
+  }
+} {1 {wrong number of arguments to function exp()}}
+
+# log()
+
+do_execsql_test log-float {
+  SELECT round(log(2.5), 6);
+} {0.916291}
+
+do_execsql_test log-int {
+  SELECT round(log(2), 6);
+} {0.693147}
+
+do_execsql_test log-string {
+  SELECT round(log('2.75'), 6);
+} {1.011601}
+
+do_execsql_test log-zero {
+  SELECT log(0);
+} {-Inf}
+
+do_execsql_test log-badarg-1 {
+  SELECT log('foo');
+} {-Inf}
+
+do_execsql_test log-null {
+  SELECT log(NULL);
+} {{}}
+
+do_test log-args-0 {
+  catchsql {
+    SELECT log();
+  }
+} {1 {wrong number of arguments to function log()}}
+
+do_test log-args-2 {
+  catchsql {
+    SELECT log(1, 2);
+  }
+} {1 {wrong number of arguments to function log()}}
+
+# log10()
+
+do_execsql_test log10-float {
+  SELECT round(log10(2.5), 6);
+} {0.39794}
+
+do_execsql_test log10-int {
+  SELECT round(log10(2), 6);
+} {0.30103}
+
+do_execsql_test log10-string {
+  SELECT round(log10('2.75'), 6);
+} {0.439333}
+
+do_execsql_test log10-zero {
+  SELECT log10(0);
+} {-Inf}
+
+do_execsql_test log10-badarg-1 {
+  SELECT log10('foo');
+} {-Inf}
+
+do_execsql_test log10-null {
+  SELECT log10(NULL);
+} {{}}
+
+do_test log10-args-0 {
+  catchsql {
+    SELECT log10();
+  }
+} {1 {wrong number of arguments to function log10()}}
+
+do_test log10-args-2 {
+  catchsql {
+    SELECT log10(1, 2);
+  }
+} {1 {wrong number of arguments to function log10()}}
+
+# sqrt()
+
+do_execsql_test sqrt-float {
+  SELECT round(sqrt(2.5), 6);
+} {1.581139}
+
+do_execsql_test sqrt-int {
+  SELECT round(sqrt(2), 6);
+} {1.414214}
+
+do_execsql_test sqrt-string {
+  SELECT round(sqrt('2.75'), 6);
+} {1.658312}
+
+do_execsql_test sqrt-zero {
+  SELECT sqrt(0);
+} {0.0}
+
+do_execsql_test sqrt-badarg-1 {
+  SELECT sqrt('foo');
+} {0.0}
+
+do_execsql_test sqrt-null {
+  SELECT sqrt(NULL);
+} {{}}
+
+do_test sqrt-args-0 {
+  catchsql {
+    SELECT sqrt();
+  }
+} {1 {wrong number of arguments to function sqrt()}}
+
+do_test sqrt-args-2 {
+  catchsql {
+    SELECT sqrt(1, 2);
+  }
+} {1 {wrong number of arguments to function sqrt()}}
+
+# ceil()
+
+do_execsql_test ceil-float {
+  SELECT round(ceil(2.5), 6);
+} {3.0}
+
+do_execsql_test ceil-int {
+  SELECT round(ceil(2), 6);
+} {2.0}
+
+do_execsql_test ceil-string {
+  SELECT round(ceil('2.75'), 6);
+} {3.0}
+
+do_execsql_test ceil-zero {
+  SELECT ceil(0);
+} {0.0}
+
+do_execsql_test ceil-badarg-1 {
+  SELECT ceil('foo');
+} {0.0}
+
+do_execsql_test ceil-null {
+  SELECT ceil(NULL);
+} {{}}
+
+do_test ceil-args-0 {
+  catchsql {
+    SELECT ceil();
+  }
+} {1 {wrong number of arguments to function ceil()}}
+
+do_test ceil-args-2 {
+  catchsql {
+    SELECT ceil(1, 2);
+  }
+} {1 {wrong number of arguments to function ceil()}}
+
+# floor()
+
+do_execsql_test floor-float {
+  SELECT round(floor(2.5), 6);
+} {2.0}
+
+do_execsql_test floor-int {
+  SELECT round(floor(2), 6);
+} {2.0}
+
+do_execsql_test floor-string {
+  SELECT round(floor('2.75'), 6);
+} {2.0}
+
+do_execsql_test floor-zero {
+  SELECT floor(0);
+} {0.0}
+
+do_execsql_test floor-badarg-1 {
+  SELECT floor('foo');
+} {0.0}
+
+do_execsql_test floor-null {
+  SELECT floor(NULL);
+} {{}}
+
+do_test floor-args-0 {
+  catchsql {
+    SELECT floor();
+  }
+} {1 {wrong number of arguments to function floor()}}
+
+do_test floor-args-2 {
+  catchsql {
+    SELECT floor(1, 2);
+  }
+} {1 {wrong number of arguments to function floor()}}
+
+finish_test

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -354,6 +354,7 @@ foreach file {
    callback.c
    delete.c
    func.c
+   math.c
    fkey.c
    insert.c
    legacy.c


### PR DESCRIPTION
Basically most of the standard C functions that were not already present in sqlite3 and a few more:

- acos(X)
- asin(X)
- atan(X)
- atan2(Y,X)
- ceil(X)
- cos(X)
- cosh(X)
- e()
- exp(X)
- floor(X)
- log(X)
- log10(X)
- pi()
- pow(X,Y)
- sin(X)
- sinh(X)
- sqrt(X)
- tan(X)
- tanh(X)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/sqlite3x/2)
<!-- Reviewable:end -->
